### PR TITLE
[KLC-1438] Replace klever.finance with klever.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The default network is the Kleverchain Mainnet, but if you want to use the Kleve
 import { web, IProvider } from '@klever/sdk-web';
 ...
   const provider:IProvider = {
-      api: 'https://api.testnet.klever.finance',
-      node: 'https://node.testnet.klever.finance'
+      api: 'https://api.testnet.klever.org',
+      node: 'https://node.testnet.klever.org'
   };
 
   window.kleverWeb.provider = provider;


### PR DESCRIPTION
This PR updates all references from the legacy `.finance` domain to the new `.org` domain. The `.finance` domain will be decommissioned at the end of April, making this change necessary to ensure continued functionality